### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "omnipay/gocardless": "dev-master",
         "omnipay/mollie": "3.*",
         "omnipay/omnipay": "~2.3",
-        "omnipay/stripe": "dev-master",
+        "omnipay/stripe": "~2.0",
         "softcommerce/omnipay-paytrace": "~1.0",
         "vink/omnipay-komoju": "~1.0"
     },


### PR DESCRIPTION
There is conflict in main invoiceninja project, because:

 - omnipay/omnipay 2.3.2 requires omnipay/stripe ~2.0
 - this package invoiceninja/omnipay-collection v0.9 requires omnipay/stripe dev-master

So I updated this package to same stripe version as omnipay