### PR TITLE
Fix omnipay/2checkout - use 2.1.1 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "meebio/omnipay-creditcall": "dev-master",
         "meebio/omnipay-secure-trading": "dev-master",
         "mfauveau/omnipay-pacnet": "~2.0",
-        "omnipay/2checkout": "dev-master#e9c079c2dde0d7ba461903b3b7bd5caf6dee1248",
+        "omnipay/2checkout": "2.1.1",
         "omnipay/bitpay": "dev-master",
         "omnipay/braintree": "^1.1",
         "omnipay/gocardless": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "omnipay/gocardless": "dev-master",
         "omnipay/mollie": "3.*",
         "omnipay/omnipay": "~2.3",
-        "omnipay/payfast": "dev-master",
+        "omnipay/payfast": "~2.0",
         "omnipay/stripe": "~2.0",
         "softcommerce/omnipay-paytrace": "~1.0",
         "vink/omnipay-komoju": "~1.0"


### PR DESCRIPTION
Signed-off-by: Kristián Feldsam <feldsam@gmail.com>